### PR TITLE
Pasting into the paste container should not trigger the creation of a snapshot

### DIFF
--- a/dist/summernote.bs3.js
+++ b/dist/summernote.bs3.js
@@ -6,7 +6,7 @@
  * Copyright 2013-2016 Alan Hong. and other contributors
  * summernote may be freely distributed under the MIT license./
  *
- * Date: 2017-12-04T23:00Z
+ * Date: 2018-05-22T22:32Z
  */
 (function (factory) {
   /* global define */
@@ -3234,6 +3234,12 @@
 
     var makeSnapshot = function () {
       var rng = range.create(editable);
+      var commonAncestor = rng.commonAncestor() || (rng.sc.isEqualNode(rng.ec)) ? rng.sc : null;
+      if (!editable.contains(commonAncestor)) {
+        // Return if the current range is outside of the editor.
+        return;
+      }
+
       var emptyBookmark = {s: {path: [], offset: 0}, e: {path: [], offset: 0}};
 
       return {
@@ -3317,6 +3323,10 @@
      */
     this.recordUndo = function () {
       var snapshot = makeSnapshot();
+
+      if (!snapshot) {
+        return;
+      }
 
       if (stack[stackOffset] && snapshot.contents === stack[stackOffset].contents &&
         JSON.stringify(snapshot.bookmark) === JSON.stringify(stack[stackOffset].bookmark)) {

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -6,7 +6,7 @@
  * Copyright 2013-2016 Alan Hong. and other contributors
  * summernote may be freely distributed under the MIT license./
  *
- * Date: 2017-12-04T23:00Z
+ * Date: 2018-05-22T22:32Z
  */
 (function (factory) {
   /* global define */
@@ -3092,6 +3092,12 @@
 
     var makeSnapshot = function () {
       var rng = range.create(editable);
+      var commonAncestor = rng.commonAncestor() || (rng.sc.isEqualNode(rng.ec)) ? rng.sc : null;
+      if (!editable.contains(commonAncestor)) {
+        // Return if the current range is outside of the editor.
+        return;
+      }
+
       var emptyBookmark = {s: {path: [], offset: 0}, e: {path: [], offset: 0}};
 
       return {
@@ -3175,6 +3181,10 @@
      */
     this.recordUndo = function () {
       var snapshot = makeSnapshot();
+
+      if (!snapshot) {
+        return;
+      }
 
       if (stack[stackOffset] && snapshot.contents === stack[stackOffset].contents &&
         JSON.stringify(snapshot.bookmark) === JSON.stringify(stack[stackOffset].bookmark)) {

--- a/dist/summernote.lite.js
+++ b/dist/summernote.lite.js
@@ -6,7 +6,7 @@
  * Copyright 2013-2016 Alan Hong. and other contributors
  * summernote may be freely distributed under the MIT license./
  *
- * Date: 2017-12-04T23:00Z
+ * Date: 2018-05-22T22:32Z
  */
 (function (factory) {
   /* global define */
@@ -3067,6 +3067,12 @@
 
     var makeSnapshot = function () {
       var rng = range.create(editable);
+      var commonAncestor = rng.commonAncestor() || (rng.sc.isEqualNode(rng.ec)) ? rng.sc : null;
+      if (!editable.contains(commonAncestor)) {
+        // Return if the current range is outside of the editor.
+        return;
+      }
+
       var emptyBookmark = {s: {path: [], offset: 0}, e: {path: [], offset: 0}};
 
       return {
@@ -3150,6 +3156,10 @@
      */
     this.recordUndo = function () {
       var snapshot = makeSnapshot();
+
+      if (!snapshot) {
+        return;
+      }
 
       if (stack[stackOffset] && snapshot.contents === stack[stackOffset].contents &&
         JSON.stringify(snapshot.bookmark) === JSON.stringify(stack[stackOffset].bookmark)) {

--- a/src/js/base/editing/History.js
+++ b/src/js/base/editing/History.js
@@ -11,6 +11,12 @@ define(['summernote/base/core/range'], function (range) {
 
     var makeSnapshot = function () {
       var rng = range.create(editable);
+      var commonAncestor = rng.commonAncestor() || (rng.sc.isEqualNode(rng.ec)) ? rng.sc : null;
+      if (!editable.contains(commonAncestor)) {
+        // Return if the current range is outside of the editor.
+        return;
+      }
+
       var emptyBookmark = {s: {path: [], offset: 0}, e: {path: [], offset: 0}};
 
       return {
@@ -94,6 +100,10 @@ define(['summernote/base/core/range'], function (range) {
      */
     this.recordUndo = function () {
       var snapshot = makeSnapshot();
+
+      if (!snapshot) {
+        return;
+      }
 
       if (stack[stackOffset] && snapshot.contents === stack[stackOffset].contents &&
         JSON.stringify(snapshot.bookmark) === JSON.stringify(stack[stackOffset].bookmark)) {


### PR DESCRIPTION
@AshDevFr Your comment about not creating a snapshot while in a different component seems to be a correct fix for [this issue](https://github.com/frontapp/front/issues/6792). So, this PR does that by ensuring the range is within the editor before creation the snapshot.