### PR TITLE
Added an option to disable the clipboard module

### DIFF
--- a/dist/summernote.bs3.js
+++ b/dist/summernote.bs3.js
@@ -6,7 +6,7 @@
  * Copyright 2013-2016 Alan Hong. and other contributors
  * summernote may be freely distributed under the MIT license./
  *
- * Date: 2017-12-04T23:00Z
+ * Date: 2018-05-23T16:34Z
  */
 (function (factory) {
   /* global define */
@@ -4708,6 +4708,12 @@
 
     this.needKeydownHook = function () {
       return (agent.isMSIE && agent.browserVersion > 10) || agent.isFF;
+    };
+
+    var options = context.options;
+
+    this.shouldInitialize = function () {
+      return !options.disableClipboard;
     };
 
     this.initialize = function () {

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -6,7 +6,7 @@
  * Copyright 2013-2016 Alan Hong. and other contributors
  * summernote may be freely distributed under the MIT license./
  *
- * Date: 2017-12-04T23:00Z
+ * Date: 2018-05-23T16:34Z
  */
 (function (factory) {
   /* global define */
@@ -4566,6 +4566,12 @@
 
     this.needKeydownHook = function () {
       return (agent.isMSIE && agent.browserVersion > 10) || agent.isFF;
+    };
+
+    var options = context.options;
+
+    this.shouldInitialize = function () {
+      return !options.disableClipboard;
     };
 
     this.initialize = function () {

--- a/dist/summernote.lite.js
+++ b/dist/summernote.lite.js
@@ -6,7 +6,7 @@
  * Copyright 2013-2016 Alan Hong. and other contributors
  * summernote may be freely distributed under the MIT license./
  *
- * Date: 2017-12-04T23:00Z
+ * Date: 2018-05-23T16:34Z
  */
 (function (factory) {
   /* global define */

--- a/src/js/base/module/Clipboard.js
+++ b/src/js/base/module/Clipboard.js
@@ -28,6 +28,12 @@ define([
       return (agent.isMSIE && agent.browserVersion > 10) || agent.isFF;
     };
 
+    var options = context.options;
+
+    this.shouldInitialize = function () {
+      return !options.disableClipboard;
+    };
+
     this.initialize = function () {
       // [workaround] getting image from clipboard
       //  - IE11 and Firefox: CTRL+v hook


### PR DESCRIPTION
This PR introduces a `disableClipboard` option, which will prevent the clipboard module from being initialized.